### PR TITLE
Hotfix/timezones once again

### DIFF
--- a/frontend/src/components/timeSelect/TimeTable.vue
+++ b/frontend/src/components/timeSelect/TimeTable.vue
@@ -54,7 +54,7 @@
     onBeforeMount(()=>cells.value = mergeCells(emptyCells, props.cells))
 
     function mergeCells(mainCells, selectedCells) {
-        selectedCells = _.pickBy(selectedCells, (cell) => dayjs.unix(cell.startTime).isBetween(startDate, endDate, 'hour', []))
+        selectedCells = _.pickBy(selectedCells, (cell) => dayjs.unix(cell.startTime).isBetween(startDate, endDate, 'hour', '[)'))
         return _.merge(_.cloneDeep(mainCells), selectedCells)
     }
 

--- a/frontend/src/snippets/fetchCalls.js
+++ b/frontend/src/snippets/fetchCalls.js
@@ -32,8 +32,8 @@ export async function createPlanning(date, webhook="") {
             "Content-Type": "application/json"
         },
         body: JSON.stringify({
-            startDate: dayjs(date.start).unix(),
-            endDate: dayjs(date.end).unix(),
+            startDate: dayjs(date.start).hour(12).minute(0).second(0).unix(),
+            endDate: dayjs(date.end).hour(12).minute(0).second(0).unix(),
             webhook: webhook
         })
     });


### PR DESCRIPTION
Changed createPlanning so that it creates a planning on the timestamp 12:00. This makes it so that it always gives everyone the same day when the table gets created.

Changed mergeCells in timeTable to exclude the last hour of endDate which ended up being the next day what resulted in allowing cells that are not supposed to be shown to be visible